### PR TITLE
Add DAOFactory deploys

### DIFF
--- a/environments/rinkeby/readme.md
+++ b/environments/rinkeby/readme.md
@@ -11,6 +11,7 @@
   - `open.aragonpm.eth`: `0x915c4a47e7c7f7ab04ac70b4bcfba257a1e8b040`
 - DAOFactory (Aragon 0.6): `0x2298d27a9b847c681d2b2c2828ab9d79013f5f1d`
 - DAOFactory (Aragon 0.7): `0xfdef49fbfe37704af55636bdd4b6bc8cd19143f6`
+- DAOFactory (Aragon 0.8): `0x137676c1941c8b12d18b12eb2215d1361aee20e0`
 
 ## Deployments
 

--- a/environments/staging/readme.md
+++ b/environments/staging/readme.md
@@ -9,6 +9,7 @@
 - APM: `0x4994a4b1215bf73f0e69ce69c2e6b43c496ad4bf`
 - DAOFactory (Aragon 0.6): `0x10e1fcca61798cae1e1bcddcbc0cf3e8c03418a6`
 - DAOFactory (Aragon 0.7): `0xbca2c99aa7018edcde60e6c5744f68003112535d`
+- DAOFactory (Aragon 0.8): `0x137676c1941c8b12d18b12eb2215d1361aee20e0`
 
 ## Deployments
 


### PR DESCRIPTION
Adding `DAOFactory` deployments used for the templates in Rinkeby and Staging environments (see https://github.com/aragon/dao-templates/pull/129)