### PR TITLE
Add permissions for Open Enterprise apps

### DIFF
--- a/environments/mainnet/permissions.yml
+++ b/environments/mainnet/permissions.yml
@@ -56,10 +56,40 @@
       - 'CREATE_VERSION_ROLE'
     - survey.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
+    - address-book.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - allocations.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - dot-voting.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - rewards.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - projects.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - open-enterprise-template.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
     - ppf-factory.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
 - address: 'ANY_ENTITY'
   permissions:
     - open.aragonpm.eth:
       - 'APMRegistry::CREATE_REPO_ROLE'
-    
+- address: '0xAd6C4A3f4550A8a5511A4e9D9E99AcbAdf92b210'
+  owner: Autark cold wallet
+  organization: Autark
+  permissions:
+    - address-book.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - allocations.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - dot-voting.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - rewards.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - projects.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - open-enterprise-template.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+- address: '0xC43B0C4b6d227536238f071fBa7e624b2A632830'
+  owner: '@sohkai' (revoked)
+  organization: Aragon One

--- a/environments/rinkeby/permissions.yml
+++ b/environments/rinkeby/permissions.yml
@@ -59,6 +59,8 @@
       - 'CREATE_VERSION_ROLE'
     - projects.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
+    - open-enterprise-template.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
     - ppf-factory.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
 - address: '0x9b1B224E0445243eF5fD102114d15136967FfB15'
@@ -105,6 +107,8 @@
     - rewards.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
     - projects.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - open-enterprise-template.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
 - address: '0x4cB3FD420555A09bA98845f0B816e45cFb230983'
   owner: '@izqui'

--- a/environments/rinkeby/permissions.yml
+++ b/environments/rinkeby/permissions.yml
@@ -151,3 +151,6 @@
   manager:
     - futarchy.open.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
+- address: '0xC43B0C4b6d227536238f071fBa7e624b2A632830'
+  owner: '@sohkai' (revoked)
+  organization: Aragon One

--- a/environments/rinkeby/permissions.yml
+++ b/environments/rinkeby/permissions.yml
@@ -49,6 +49,16 @@
       - 'CREATE_VERSION_ROLE'
     - survey.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
+    - address-book.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - allocations.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - dot-voting.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - rewards.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - projects.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
     - ppf-factory.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
 - address: '0x9b1B224E0445243eF5fD102114d15136967FfB15'
@@ -81,6 +91,20 @@
     - tap.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
     - fundraising-multisig-template.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+- address: '0xE99c829804212D4B8bFb6FBF85EB5D8E8454cB47'
+  owner: Autark testnet cold wallet
+  organization: Autark
+  permissions:
+    - address-book.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - allocations.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - dot-voting.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - rewards.aragonpm.eth:
+      - 'CREATE_VERSION_ROLE'
+    - projects.aragonpm.eth:
       - 'CREATE_VERSION_ROLE'
 - address: '0x4cB3FD420555A09bA98845f0B816e45cFb230983'
   owner: '@izqui'


### PR DESCRIPTION
cc @izqui @Quazia 

### Mainnet

- `address-book.aragonpm.eth`: `0x5d47d1786d68c91c43ac21b3a9e485cac2b50644`
- `allocations.aragonpm.eth`: `0x4aa5d6622c7fe568dd3a20026c25e688194ee1be`
- `dot-voting.aragonpm.eth`: `0xd461886059dc6a06dc052474ac9bc2fd172465db`
- `projects.aragonpm.eth`: `0x0a9be50c24f8536fa11d17a77d0baa4290f720fc`
- `rewards.aragonpm.eth`: `0x1fe9e2ca520967521f644caa87c5aed34bd6e049`
- `open-enterprise-template.aragonpm.eth`: `0xe3dadc75cc90b9ed3ed72126ba24e79f9b4c2a6f`

### Rinkeby

- `address-book.aragonpm.eth`: `0xb630e32812f96a2ba067ad91e7b4bfbb338b9b61`
- `allocations.aragonpm.eth`: `0x78b2bf86b7f73874e937dd678ee7fc0144960983`
- `dot-voting.aragonpm.eth`: `0x2202c7909cfa2cffaeb3d816831fb9f2dc840196`
- `projects.aragonpm.eth`: `0xfb6360c56274fddf0cf0e28bbc562095e1600838`
- `rewards.aragonpm.eth`: `0xeed29eac7b5e594a8a4e353f84e70d9b562ae258`
- `open-enterprise-template.aragonpm.eth`: `0xd8a5977f8c5f8226aa6d15668ccf6534fccfd41b`

Todo:

- [x] Transfer repo management back to A1 cold wallet after Autark has published first versions
- [x] Revoke `@sohkai`'s account on Rinkeby
- [x] Revoke `@sohkai`'s account on Mainnet